### PR TITLE
feat/hyphenate blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import compress from "astro-compress"
 import robots from "astro-robots-txt"
 
 import { remarkDeruntify } from "./remark-plugins/remark-deruntify.mjs"
+import { remarkHyphenate } from "./remark-plugins/remark-hyphenate.mjs"
 import { remarkReadingTime } from "./remark-plugins/remark-reading-time.mjs"
 
 // https://astro.build/config
@@ -45,7 +46,7 @@ export default defineConfig({
 	],
 	markdown: {
 		drafts: true,
-		remarkPlugins: [remarkDeruntify, remarkReadingTime],
+		remarkPlugins: [remarkHyphenate, remarkDeruntify, remarkReadingTime],
 		shikiConfig: {
 			theme: "poimandres",
 		},

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "blaze-slider": "^1.9.1",
     "clsx": "^1.2.1",
     "got": "^12.6.0",
+    "hyphenopoly": "^5.0.0",
     "mdast-util-to-string": "^3.1.0",
     "node-html-parser": "^6.1.4",
     "postcss": "^8.4.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ specifiers:
   eslint-plugin-jsx-a11y: ^6.6.1
   eslint-plugin-prettier: ^4.2.1
   got: ^12.6.0
+  hyphenopoly: ^5.0.0
   mdast-util-to-string: ^3.1.0
   node-html-parser: ^6.1.4
   npm-run-all: ^4.1.5
@@ -82,6 +83,7 @@ dependencies:
   blaze-slider: 1.9.1
   clsx: 1.2.1
   got: 12.6.0
+  hyphenopoly: 5.0.0
   mdast-util-to-string: 3.1.0
   node-html-parser: 6.1.4
   postcss: 8.4.21
@@ -3818,6 +3820,11 @@ packages:
 
   /hyphenate-style-name/1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
+    dev: false
+
+  /hyphenopoly/5.0.0:
+    resolution: {integrity: sha512-VsuspLqLzagYHqshj9OVLYsbG2oRZHur0SkPQtESzwzo4OYQhLwlNngadKZvDd6WSKeoL15eer2jC6MQiQBVPw==}
+    engines: {node: '>=14'}
     dev: false
 
   /ieee754/1.2.1:

--- a/remark-plugins/remark-hyphenate.mjs
+++ b/remark-plugins/remark-hyphenate.mjs
@@ -1,0 +1,32 @@
+import hyphenopoly from "hyphenopoly"
+import { readFileSync } from "node:fs"
+import { dirname } from "path"
+import { visit } from "unist-util-visit"
+import { fileURLToPath } from "url"
+
+function loaderSync(file) {
+	const cwd = dirname(fileURLToPath(import.meta.url))
+	return readFileSync(`${cwd}/../node_modules/hyphenopoly/patterns/${file}`)
+}
+
+const hyphenator = hyphenopoly.config({
+	exceptions: {
+		"en-us": "Astro",
+	},
+	loaderSync,
+	require: ["en-us"],
+	defaultLanguage: "en-us",
+	sync: true,
+})
+
+export function remarkHyphenate() {
+	function transformer(tree) {
+		visit(tree, "text", function (node) {
+			const hyphenated = hyphenator(node.value)
+
+			node.value = hyphenated
+		})
+	}
+
+	return transformer
+}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,10 +1,8 @@
 ---
-import type { HTMLAttributes } from "astro/types"
-
 import Dropdown from "@components/Dropdown"
-// import Image from "@components/Image.astro"
 import LazyImage from "@components/LazyImage.astro"
 import ThemeToggle from "@components/ThemeToggle"
+import type { HTMLAttributes } from "astro/types"
 
 interface Props extends HTMLAttributes<"section"> {}
 

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,17 +1,19 @@
 ---
 import type { HTMLAttributes } from "astro/types"
 
-interface Props extends HTMLAttributes<"main"> {}
+interface Props extends HTMLAttributes<any> {
+	as?: keyof HTMLElementTagNameMap
+}
 
-const { class: className = "", ...attrs } = Astro.props as Props
+const { as: Prose = "main", class: className = "", ...attrs } = Astro.props as Props
 ---
 
-<main
+<Prose
 	class:list={[
 		className,
-		"prose font-serif prose-lg prose-zinc max-w-max prose-headings:font-sans prose-headings:font-semibold prose-blockquote:font-serif prose-blockquote:text-xl prose-blockquote:italic dark:prose-invert prose-pre:text-sm prose-code:text-sm",
+		"prose font-serif prose-lg prose-zinc max-w-max prose-headings:font-sans prose-headings:font-semibold prose-blockquote:font-serif prose-blockquote:text-xl prose-blockquote:italic dark:prose-invert prose-pre:text-sm prose-code:text-sm [hyphens:manual] text-justify tracking-[-0.022em]",
 	]}
 	{...attrs}
 >
 	<slot />
-</main>
+</Prose>

--- a/src/content/blog/font-files-github-npm-registry.mdx
+++ b/src/content/blog/font-files-github-npm-registry.mdx
@@ -2,6 +2,7 @@
 title: Use GitHub Packages to store font files as a private NPM package
 description: GitHub Packages allow you to store up to 500 MB of NPM packages privately, for free.
 published: 2023-03-18
+modified: 2023-03-31
 tags:
   - fonts
   - vercel
@@ -15,7 +16,7 @@ My reasoning here was twofold. I wanted to help protect the type foundry's intel
 
 [Blanco](https://www.fostertype.com/retail-type/blanco) &mdash; the serif typeface I use for body copy on this site &mdash; specifies in their [EULA](https://www.fostertype.com/licence) that the licensor cannot "store or use font files in a way that makes them available for use by any third party." This, I think, rules out storing the font files as-is in a public GitHub repository.
 
-As I put the finishing touches on this site's latest design, I remembered Kelly's post and decided to tweak her process for my private packages.
+As I put the finishing touches on this site's latest design, I remembered Kelly's post and decided to tweak her process for my private font packages.
 
 <p
 	class="not-prose text-center text-2xl text-gray-400 dark:text-gray-500"
@@ -98,7 +99,7 @@ Let's take a look at the `index.css` file:
 	font-weight: 400;
 	font-style: normal;
 	font-display: auto;
-	font-feature-settings: "kern" on, "liga" on, "ss01";
+	font-feature-settings: "kern" on, "liga" on, "ss01" on;
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
 		U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/src/content/blog/suggest-line-breaks-markdown.mdx
+++ b/src/content/blog/suggest-line-breaks-markdown.mdx
@@ -1,0 +1,150 @@
+---
+title: Suggest better line breaks in your Astro Markdown files
+description: Let's get wacky and wild on the web and justify our text without guilt.
+published: 2023-03-31
+tags:
+  - markdown
+  - remark
+  - astro
+  - line breaks
+  - hyphens
+---
+
+import Stackblitz from "@components/Stackblitz.astro"
+
+Adding on to my previous post, [Remove runts from your Astro Markdown files with ~15 lines of code](/blog/remove-runts-markdown), I wanted to share another quick tip for improving the layout of your Markdown prose.
+
+We're going to write a custom Remark plugin to suggest line breaks in our Markdown content. Doing this allows us to use the `hyphens: manual` CSS property while avoiding awkward breaks in places they shouldn't be.
+
+## Wait, can't CSS fix this?
+
+CSS does have a property for breaking words and inserting hyphens (`hyphens: auto`), but it's not super granular about the words it breaks. For example, words with only 5 letters will get broken just as easily as words with 20 letters. _Yuck!_
+
+There is _another_ CSS property to control the length of words that get broken (`hyphenate-limit-chars`), but [it's not yet widely supported](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-limit-chars).
+
+This custom plugin I wrote sprinkles line break opportunities into your markup by inserting the `&shy;` entity. The `&shy;` entity is a _soft_ hyphen, which means it's a suggestion to the browser to insert hyphens there when the `hyphens: manual` CSS property is used.
+
+## Hyphenopoly to the rescue
+
+Under the hood, I'm using the package `hyphenopoly` to insert these soft hyphens everywhere. Per the package's documentation, hyphenopoly uses Franklin M. Liang's algorithm developed for TeX. If you're curious how that algorithm works, I suggest you [check out the project's README](https://github.com/mnater/Hyphenopoly/blob/master/README.md#user-content-automatic-hyphenation).
+
+## Getting started
+
+**Note:** If you need help setting up your Astro blog for Markdown (`.md` or `.mdx`), I recommend following [Astro's "Build a Blog" tutorial](https://docs.astro.build/en/tutorial/0-introduction/).
+
+This time, we'll need two npm packages:
+
+```zsh
+npm install unist-util-visit hyphenopoly
+```
+
+### Writing our plugin
+
+Now, we'll create the JS file that will actually do the transformation. I like to store my custom plugins in a folder called `/remark-plugins` at the root of my project, but you're welcome to put them wherever.
+
+```js
+import hyphenopoly from "hyphenopoly"
+import { readFileSync } from "node:fs"
+import { dirname } from "path"
+import { visit } from "unist-util-visit"
+import { fileURLToPath } from "url"
+
+function loaderSync(file) {
+	const cwd = dirname(fileURLToPath(import.meta.url))
+	return readFileSync(`${cwd}/../node_modules/hyphenopoly/patterns/${file}`)
+}
+
+const hyphenator = hyphenopoly.config({
+	exceptions: {
+		"en-us": "Houston",
+	},
+	loaderSync,
+	// dontHyphenateClass: 'donthyphenate',
+	// minWordLength: 6,
+	require: ["en-us"],
+	defaultLanguage: "en-us",
+	sync: true,
+})
+
+export function remarkHyphenate() {
+	function transformer(tree) {
+		visit(tree, "text", function (node) {
+			const hyphenated = hyphenator(node.value)
+
+			node.value = hyphenated
+		})
+	}
+
+	return transformer
+}
+```
+
+This Remark plugin has a bit more going on than my last one. That's because hyphenopoly _must_ have a pattern specified to apply the soft hyphens. The package ships with a ton of built-in language support (71 by my count!), so you have to tell it which `.wasm` file to load up.
+
+In my case, I'm using the `en-us` pattern. [You can find the full list of patterns here](https://github.com/mnater/Hyphenopoly/tree/master/patterns).
+
+**Warning: Boring code explanation time!**
+
+1. The `loaderSync` function is a bit of a hack -- it loads the `en-us.wasm` file from the `hyphenopoly` package directory. I'm not sure if there's a better way to do this, but it works for now.
+2. `hyphenator` configures hyphenopoly:
+   - We pass in our custom loader with the `.wasm` pattern, and specify which language(s) we want to use.
+   - You can specify exceptions to the hyphenation rules, which I've done for the word "Houston."
+   - You can specify a minimum word length for hyphenation, but I've left that commented out for now. Six is the default, and that was good enough for me.
+   - I've also commented out the optional `dontHyphenateClass` setting, which allows you to specify a CSS class that will prevent hyphenation from happening.
+3. We're using `unist-util-visit` to traverse the Markdown AST and replace the text content of each (textual) DOM node (`node.value`) with our hyphenated text.
+
+### Enabling the plugin in Astro
+
+The last thing we have to do is tell Astro to use our new plugin. We can do this by adding a `remarkPlugins` array to our `astro.config.mjs` file:
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config"
+
+import mdx from "@astrojs/mdx"
+
+import { remarkHyphenate } from "./remark-plugins/remark-hyphenate.mjs"
+
+export default defineConfig({
+	integrations: [mdx()],
+	markdown: {
+		remarkPlugins: [remarkHyphenate],
+	},
+})
+```
+
+## Enable word breaks in CSS
+
+To reap the full benefit of our custom plugin, we need to add at least one CSS property to our prose content:
+
+```css
+hyphens: manual;
+text-align: justify; /* Optionally, you can now use `justify` */
+```
+
+I added the justification because I like the way it looks, but it's not necessary. You can safely use it because we've told the browser where it can break up words in our prose.
+
+There's not much to it other than that! Feel free to tinker with the hyphenopoly settings to your heart's content.
+
+## Further improvements
+
+I'm still not 100% happy with the way this plugin works. I'd like a better method to load in the `.wasm` pattern file. My loader function seems rather brittle.
+
+Out of the box, hyphenopoly provides orphan control (they actually mean "runts"), which I'd like to test. If it does as good a job as my last plugin, then that's redundant code I can happily rip out.
+
+## Working example
+
+<Stackblitz
+	class="not-prose -mx-4 md:-mx-16"
+	projectId="github-ogfesm"
+	file="remark-plugins/remark-hyphenate.mjs"
+/>
+
+Feel free to [drop me a line](mailto:john@eatmon.co) or [tweet at me](https://twitter.com/johneatmon_). I am always open to improving this tutorial or my code examples.
+
+---
+
+## Further reading
+
+- [Hyphenopoly's automatic hyphenation algorithm](https://github.com/mnater/Hyphenopoly/blob/master/README.md#user-content-automatic-hyphenation) from the Hyphenopoly README
+- [Word Hy-phen-a-tion by Com-put-er](https://www.tug.org/docs/liang/) by Frank Liang

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -41,7 +41,7 @@ const description =
 				Introduction
 			</h2>
 			<div class="flex-grow">
-				<Prose class="!leading-[28px]" set:html={Introduction.compiledContent()} />
+				<Prose as="div" class="!leading-[28px]" set:html={Introduction.compiledContent()} />
 			</div>
 		</div>
 	</section>
@@ -54,7 +54,7 @@ const description =
 				After hours
 			</h2>
 			<div class="flex-grow">
-				<Prose class="!leading-[28px]" set:html={AfterHours.compiledContent()} />
+				<Prose as="div" class="!leading-[28px]" set:html={AfterHours.compiledContent()} />
 			</div>
 		</div>
 	</section>
@@ -64,7 +64,7 @@ const description =
 				My mission
 			</h2>
 			<div class="flex-grow">
-				<Prose class="!leading-[28px]" set:html={Mission.compiledContent()} />
+				<Prose as="div" class="!leading-[28px]" set:html={Mission.compiledContent()} />
 			</div>
 		</div>
 	</section>
@@ -74,7 +74,7 @@ const description =
 				Experience
 			</h2>
 			<div class="flex-grow">
-				<Prose class="!leading-[28px] mb-8" set:html={Experience.compiledContent()} />
+				<Prose as="div" class="!leading-[28px] mb-8" set:html={Experience.compiledContent()} />
 				<FancyButton href="/work/prosource" class="!block sm:!inline-block">Learn more</FancyButton>
 			</div>
 		</div>
@@ -137,6 +137,6 @@ const description =
 		</div>
 	</section>
 	<MapSection class="pt-16">
-		<Prose class="!leading-[28px]" set:html={Location.compiledContent()} />
+		<Prose as="div" class="!leading-[28px]" set:html={Location.compiledContent()} />
 	</MapSection>
 </BaseLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23,8 +23,6 @@
 	}
 
 	html {
-		@apply antialiased;
-
 		&:focus-within {
 			scroll-behavior: smooth;
 		}
@@ -32,7 +30,7 @@
 
 	body {
 		min-height: theme("height.screen");
-		text-rendering: optimizeSpeed;
+		text-rendering: optimizeLegibility;
 		overflow-y: scroll;
 		scrollbar-gutter: stable both-edges;
 	}
@@ -41,8 +39,8 @@
 		text-decoration-skip-ink: auto;
 	}
 
-	:where(:not(.prose)).font-serif {
-		font-size: 1.125em;
+	.font-serif {
+		font-feature-settings: "kern" on, "liga" on, "ss01" on;
 	}
 
 	@media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
- fix `<Prose>` component by allowing other element types (rather than just `<main>`
- improve a11y on about page by removing duplication landmark elements (`<main>`)
- general clean up/improvements
- new Remark plugin that inserts `&shy;` entities into Markdown content!
- enable `hyphens: manual` and `text-align: justify` on prose content 😱
- new blog post about hyphenation strategy + Remark plugin